### PR TITLE
Remove all remaining traces of older whw01 naming scheme

### DIFF
--- a/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
+++ b/target/linux/ipq40xx/files/arch/arm/boot/dts/qcom-ipq4018-whw01.dts
@@ -6,7 +6,7 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	model = "Linksys WHW01 v1";
+	model = "Linksys WHW01";
 	compatible = "linksys,whw01";
 
 	aliases {
@@ -305,14 +305,14 @@
 
 &wifi0 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "linksys-whw01-v1";
+	qcom,ath10k-calibration-variant = "linksys-whw01";
 	nvmem-cell-names = "pre-calibration";
 	nvmem-cells = <&precal_art_1000>;
 };
 
 &wifi1 {
 	status = "okay";
-	qcom,ath10k-calibration-variant = "linksys-whw01-v1";
+	qcom,ath10k-calibration-variant = "linksys-whw01";
 	nvmem-cell-names = "pre-calibration";
 	nvmem-cells = <&precal_art_5000>;
 };

--- a/target/linux/ipq40xx/image/generic.mk
+++ b/target/linux/ipq40xx/image/generic.mk
@@ -721,11 +721,10 @@ define Device/linksys_mr8300
 endef
 TARGET_DEVICES += linksys_mr8300
 
-define Device/linksys_whw01-v1
+define Device/linksys_whw01
 	$(call Device/FitzImage)
 	DEVICE_VENDOR := Linksys
 	DEVICE_MODEL := WHW01
-	DEVICE_VARIANT := v1
 	KERNEL_SIZE := 6144k
 	IMAGE_SIZE := 75776K
 	SOC := qcom-ipq4018
@@ -736,7 +735,7 @@ define Device/linksys_whw01-v1
 	IMAGE/factory.bin := append-kernel | pad-to $$$$(KERNEL_SIZE) | append-ubi | linksys-image type=WHW01
 	DEVICE_PACKAGES := uboot-envtools kmod-leds-pca963x
 endef
-TARGET_DEVICES += linksys_whw01-v1
+TARGET_DEVICES += linksys_whw01
 
 define Device/luma_wrtq-329acn
 	$(call Device/FitImage)


### PR DESCRIPTION
Remove all remaining references to "v1" in old whw01 naming scheme.